### PR TITLE
Add Github templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+## Guidelines
+
+* We are interested in various kinds of improvements for this tutorial; please feel free to raise an [Issue](https://github.com/rgreinho/go-cli-crashcourse/issues) if you would like to work on something major to ensure efficient collaboration and avoid duplicate effort.
+* Use the provided templates to file an [Issue](https://github.com/rgreinho/go-cli-crashcourse/issues) or a [Pull Request](https://github.com/rgreinho/go-cli-crashcourse/pulls).
+* Create a topic branch from where you want to base your work.
+* Make sure you have added tests for your changes.
+* Run all the tests to ensure nothing else was accidentally broken.
+* Reformat the code by following the formatting section below.
+* Submit a [Pull Request](https://github.com/rgreinho/go-cli-crashcourse/pulls).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+Issue Type
+----------
+<!-- Define the type of issue you're reporting -->
+- Bug report
+- Feature request
+
+Expected Behavior
+-----------------
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+Current Behavior
+----------------
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+Possible Solution
+-----------------
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+Steps to Reproduce (for bugs)
+-----------------------------
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+Context
+-------
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+Your Environment
+----------------
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Operating System and version (desktop or mobile):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+Description
+-----------
+<!--- Describe your changes in detail -->
+
+Motivation and Context
+----------------------
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+How Has This Been Tested?
+-------------------------
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+Types of changes
+----------------
+<!--- What types of changes does your code introduce? Remove what does not apply. -->
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to change)
+- Code cleanup / Refactoring
+- Documentation
+
+Checklist
+---------
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [] I have written unit tests.
+- [] I have updated the documentation accordingly.
+
+<!-- Place the *FULL* URL of the issue here it this PR fixes an existing issue. -->
+Fixes: https://github.com/rgreinho/go-cli-crashcourse/issues


### PR DESCRIPTION
Github templates help the users/contributors to write comsistent and
comprehensives issues or pull requests.